### PR TITLE
[#53] 이벤트 api 

### DIFF
--- a/src/main/kotlin/sosteam/deamhome/domain/account/service/wishlist/WishListReadService.kt
+++ b/src/main/kotlin/sosteam/deamhome/domain/account/service/wishlist/WishListReadService.kt
@@ -7,17 +7,16 @@ import org.springframework.stereotype.Service
 import sosteam.deamhome.domain.account.service.AccountValidService
 import sosteam.deamhome.domain.item.handler.response.ItemResponse
 import sosteam.deamhome.domain.item.repository.ItemRepository
+import sosteam.deamhome.domain.item.service.ItemSearchService
 
 @Service
 class WishListReadService(
-	private val itemRepository: ItemRepository,
 	private val accountValidService: AccountValidService,
+	private val itemSearchService: ItemSearchService,
 ) {
 	suspend fun getAllWishList(userId: String, page: Int, pageSize: Int = 10): List<ItemResponse> {
 		val account = accountValidService.getAccountByUserId(userId)
-		val pageRequest: PageRequest = PageRequest.of(page, pageSize, Sort.by(Sort.Order.desc("id")))
-		return itemRepository.findByIdIn(account.getWishList(), pageRequest)
-			.toList()
-			.map { ItemResponse.fromItem(it) }
+		return itemSearchService
+			.findItemByPublicIdIn(account.getWishList(), page, pageSize)
 	}
 }

--- a/src/main/kotlin/sosteam/deamhome/domain/event/entity/Event.kt
+++ b/src/main/kotlin/sosteam/deamhome/domain/event/entity/Event.kt
@@ -1,6 +1,7 @@
 package sosteam.deamhome.domain.event.entity
 
 import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Column
 import org.springframework.data.relational.core.mapping.Table
 import sosteam.deamhome.global.entity.BaseEntity
 import java.time.LocalDateTime
@@ -9,8 +10,10 @@ import java.time.LocalDateTime
 data class Event(
     @Id
     var id: Long?,
-    var started: LocalDateTime,
-    var ended: LocalDateTime,
+    @Column("started_at")
+    var startedAt: LocalDateTime,
+    @Column("ended_at")
+    var endedAt: LocalDateTime,
     var title: String,
     var contents: String?,
     var thumbnail: String?,

--- a/src/main/kotlin/sosteam/deamhome/domain/event/entity/Event.kt
+++ b/src/main/kotlin/sosteam/deamhome/domain/event/entity/Event.kt
@@ -1,0 +1,21 @@
+package sosteam.deamhome.domain.event.entity
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Table
+import sosteam.deamhome.global.entity.BaseEntity
+import java.time.LocalDateTime
+
+@Table("event")
+data class Event(
+    @Id
+    var id: Long?,
+    var started: LocalDateTime,
+    var ended: LocalDateTime,
+    var title: String,
+    var contents: String?,
+    var thumbnail: String?,
+    var items: MutableList<String> = mutableListOf(),
+
+): BaseEntity(){
+    var images: MutableList<String> = mutableListOf()
+}

--- a/src/main/kotlin/sosteam/deamhome/domain/event/exception/EventNotFoundException.kt
+++ b/src/main/kotlin/sosteam/deamhome/domain/event/exception/EventNotFoundException.kt
@@ -1,0 +1,15 @@
+package sosteam.deamhome.domain.event.exception
+
+import org.springframework.graphql.execution.ErrorType
+import sosteam.deamhome.global.exception.CustomGraphQLException
+
+class EventNotFoundException (
+    errorCode: String = "EVENT_NOT_FOUND_EXCEPTION",
+
+    @JvmField
+    @Suppress("INAPPLICABLE_JVM_FIELD")
+    override val message: String = "유효하지 않은 이벤트입니다."
+):
+    CustomGraphQLException(errorCode, ErrorType.NOT_FOUND, message) {
+    override fun getMessage(): String = super.message
+}

--- a/src/main/kotlin/sosteam/deamhome/domain/event/exception/InvalidEventTimeException.kt
+++ b/src/main/kotlin/sosteam/deamhome/domain/event/exception/InvalidEventTimeException.kt
@@ -1,0 +1,15 @@
+package sosteam.deamhome.domain.event.exception
+
+import org.springframework.graphql.execution.ErrorType
+import sosteam.deamhome.global.exception.CustomGraphQLException
+
+class InvalidEventTimeException (
+    errorCode: String = "INVALID_EVENT_TIME_EXCEPTION",
+
+    @JvmField
+    @Suppress("INAPPLICABLE_JVM_FIELD")
+    override val message: String = "이벤트 시작시간은 종료시간보다 앞서야 합니다"
+):
+    CustomGraphQLException(errorCode, ErrorType.NOT_FOUND, message) {
+    override fun getMessage(): String = super.message
+}

--- a/src/main/kotlin/sosteam/deamhome/domain/event/handler/EventResolver.kt
+++ b/src/main/kotlin/sosteam/deamhome/domain/event/handler/EventResolver.kt
@@ -4,11 +4,13 @@ import org.springframework.graphql.data.method.annotation.Argument
 import org.springframework.graphql.data.method.annotation.MutationMapping
 import org.springframework.graphql.data.method.annotation.QueryMapping
 import org.springframework.web.bind.annotation.RestController
+import sosteam.deamhome.domain.event.handler.request.EventPageRequest
 import sosteam.deamhome.domain.event.handler.request.EventRequest
 import sosteam.deamhome.domain.event.handler.response.EventInfoResponse
 import sosteam.deamhome.domain.event.handler.response.EventItemResponse
 import sosteam.deamhome.domain.event.service.EventCreateService
 import sosteam.deamhome.domain.event.service.EventReadService
+import sosteam.deamhome.domain.item.handler.response.ItemResponse
 
 @RestController
 class EventResolver (
@@ -31,5 +33,11 @@ class EventResolver (
     @QueryMapping
     suspend fun getEventInfo(@Argument eventId: Long): EventInfoResponse{
         return eventReadService.getEventInfo(eventId)
+    }
+
+    // 이벤트 진행중인 아이템 publicId 매핑해서 리턴
+    @QueryMapping
+    suspend fun getEventItems(@Argument request: EventPageRequest): List<ItemResponse>{
+        return eventReadService.getEventItems(request)
     }
 }

--- a/src/main/kotlin/sosteam/deamhome/domain/event/handler/EventResolver.kt
+++ b/src/main/kotlin/sosteam/deamhome/domain/event/handler/EventResolver.kt
@@ -1,0 +1,35 @@
+package sosteam.deamhome.domain.event.handler
+
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.MutationMapping
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.web.bind.annotation.RestController
+import sosteam.deamhome.domain.event.handler.request.EventRequest
+import sosteam.deamhome.domain.event.handler.response.EventInfoResponse
+import sosteam.deamhome.domain.event.handler.response.EventItemResponse
+import sosteam.deamhome.domain.event.service.EventCreateService
+import sosteam.deamhome.domain.event.service.EventReadService
+
+@RestController
+class EventResolver (
+    private val eventCreateService: EventCreateService,
+    private val eventReadService: EventReadService,
+){
+    // 이벤트 생성
+    @MutationMapping
+    suspend fun createEvent(@Argument request: EventRequest): EventInfoResponse{
+        return eventCreateService.createEvent(request)
+    }
+
+    // 현재 진행중인 이벤트 리스트 가져오기
+    @QueryMapping
+    suspend fun getEventList(): List<EventItemResponse>{
+        return eventReadService.getEventList()
+    }
+
+    // eventId 이용해서 클릭 시 상세정보 조회
+    @QueryMapping
+    suspend fun getEventInfo(@Argument eventId: Long): EventInfoResponse{
+        return eventReadService.getEventInfo(eventId)
+    }
+}

--- a/src/main/kotlin/sosteam/deamhome/domain/event/handler/request/EventPageRequest.kt
+++ b/src/main/kotlin/sosteam/deamhome/domain/event/handler/request/EventPageRequest.kt
@@ -1,0 +1,7 @@
+package sosteam.deamhome.domain.event.handler.request
+
+data class EventPageRequest (
+    val eventId: Long,
+    val page: Int =0,
+    val pageSize: Int
+)

--- a/src/main/kotlin/sosteam/deamhome/domain/event/handler/request/EventRequest.kt
+++ b/src/main/kotlin/sosteam/deamhome/domain/event/handler/request/EventRequest.kt
@@ -1,0 +1,30 @@
+package sosteam.deamhome.domain.event.handler.request
+
+import sosteam.deamhome.domain.event.entity.Event
+import sosteam.deamhome.global.entity.DTO
+import sosteam.deamhome.global.image.handler.request.ImageRequest
+import java.time.LocalDateTime
+
+// 이벤트 생성 요청 Request
+data class EventRequest (
+
+    val started: LocalDateTime,
+    val ended: LocalDateTime,
+    val title: String,
+    val contents: String?,
+    val thumbnail: String?,
+    val items: MutableList<String>?,
+    val images: List<ImageRequest>?,
+): DTO {
+    override fun asDomain(): Event {
+       return Event(
+           id = null,
+           started = started,
+           ended = ended,
+           title = title,
+           contents = contents,
+           thumbnail = thumbnail,
+           items = items ?: mutableListOf() ,
+       )
+    }
+}

--- a/src/main/kotlin/sosteam/deamhome/domain/event/handler/request/EventRequest.kt
+++ b/src/main/kotlin/sosteam/deamhome/domain/event/handler/request/EventRequest.kt
@@ -8,8 +8,8 @@ import java.time.LocalDateTime
 // 이벤트 생성 요청 Request
 data class EventRequest (
 
-    val started: LocalDateTime,
-    val ended: LocalDateTime,
+    val startedAt: LocalDateTime,
+    val endedAt: LocalDateTime,
     val title: String,
     val contents: String?,
     val thumbnail: String?,
@@ -19,8 +19,8 @@ data class EventRequest (
     override fun asDomain(): Event {
        return Event(
            id = null,
-           started = started,
-           ended = ended,
+           startedAt = startedAt,
+           endedAt = endedAt,
            title = title,
            contents = contents,
            thumbnail = thumbnail,

--- a/src/main/kotlin/sosteam/deamhome/domain/event/handler/response/EventInfoResponse.kt
+++ b/src/main/kotlin/sosteam/deamhome/domain/event/handler/response/EventInfoResponse.kt
@@ -6,8 +6,8 @@ import java.time.LocalDateTime
 // 전체 정보 response
 class EventInfoResponse (
     val id: Long?,
-    val started: LocalDateTime,
-    val ended: LocalDateTime,
+    val startedAt: LocalDateTime,
+    val endedAt: LocalDateTime,
     val title: String,
     val contents: String?,
     val thumbnail: String?,
@@ -18,8 +18,8 @@ class EventInfoResponse (
         fun fromEvent(event: Event): EventInfoResponse{
             return EventInfoResponse(
                 id= event.id,
-                started = event.started,
-                ended = event.ended,
+                startedAt = event.startedAt,
+                endedAt = event.endedAt,
                 title = event.title,
                 contents = event.contents,
                 thumbnail = event.thumbnail,

--- a/src/main/kotlin/sosteam/deamhome/domain/event/handler/response/EventInfoResponse.kt
+++ b/src/main/kotlin/sosteam/deamhome/domain/event/handler/response/EventInfoResponse.kt
@@ -1,0 +1,31 @@
+package sosteam.deamhome.domain.event.handler.response
+
+import sosteam.deamhome.domain.event.entity.Event
+import java.time.LocalDateTime
+
+// 전체 정보 response
+class EventInfoResponse (
+    val id: Long?,
+    val started: LocalDateTime,
+    val ended: LocalDateTime,
+    val title: String,
+    val contents: String?,
+    val thumbnail: String?,
+    val items: MutableList<String>,
+    val images: MutableList<String>,
+){
+    companion object{
+        fun fromEvent(event: Event): EventInfoResponse{
+            return EventInfoResponse(
+                id= event.id,
+                started = event.started,
+                ended = event.ended,
+                title = event.title,
+                contents = event.contents,
+                thumbnail = event.thumbnail,
+                items = event.items,
+                images = event.images,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/sosteam/deamhome/domain/event/handler/response/EventItemResponse.kt
+++ b/src/main/kotlin/sosteam/deamhome/domain/event/handler/response/EventItemResponse.kt
@@ -6,8 +6,8 @@ import java.time.LocalDateTime
 // 리스트 안 아이템 간략 response
 class EventItemResponse (
     val id: Long?,
-    val started: LocalDateTime,
-    val ended: LocalDateTime,
+    val startedAt: LocalDateTime,
+    val endedAt: LocalDateTime,
     val title: String,
     val contents: String?,
     val thumbnail: String?,
@@ -17,8 +17,8 @@ class EventItemResponse (
         fun fromEvent(event: Event): EventItemResponse{
             return EventItemResponse(
                 id= event.id,
-                started = event.started,
-                ended = event.ended,
+                startedAt = event.startedAt,
+                endedAt = event.endedAt,
                 title = event.title,
                 contents = event.contents,
                 thumbnail = event.thumbnail,

--- a/src/main/kotlin/sosteam/deamhome/domain/event/handler/response/EventItemResponse.kt
+++ b/src/main/kotlin/sosteam/deamhome/domain/event/handler/response/EventItemResponse.kt
@@ -1,0 +1,28 @@
+package sosteam.deamhome.domain.event.handler.response
+
+import sosteam.deamhome.domain.event.entity.Event
+import java.time.LocalDateTime
+
+// 리스트 안 아이템 간략 response
+class EventItemResponse (
+    val id: Long?,
+    val started: LocalDateTime,
+    val ended: LocalDateTime,
+    val title: String,
+    val contents: String?,
+    val thumbnail: String?,
+
+){
+    companion object{
+        fun fromEvent(event: Event): EventItemResponse{
+            return EventItemResponse(
+                id= event.id,
+                started = event.started,
+                ended = event.ended,
+                title = event.title,
+                contents = event.contents,
+                thumbnail = event.thumbnail,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/sosteam/deamhome/domain/event/repository/EventRepository.kt
+++ b/src/main/kotlin/sosteam/deamhome/domain/event/repository/EventRepository.kt
@@ -8,5 +8,5 @@ import java.time.LocalDateTime
 
 @GraphQlRepository
 interface EventRepository: CoroutineCrudRepository<Event, Long> {
-    suspend fun findByEndedAfter(@Param("endDate") endDate: LocalDateTime): List<Event>
+    suspend fun findByEndedAtAfter(@Param("endDate") endDate: LocalDateTime): List<Event>
 }

--- a/src/main/kotlin/sosteam/deamhome/domain/event/repository/EventRepository.kt
+++ b/src/main/kotlin/sosteam/deamhome/domain/event/repository/EventRepository.kt
@@ -1,0 +1,12 @@
+package sosteam.deamhome.domain.event.repository
+
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import org.springframework.data.repository.query.Param
+import org.springframework.graphql.data.GraphQlRepository
+import sosteam.deamhome.domain.event.entity.Event
+import java.time.LocalDateTime
+
+@GraphQlRepository
+interface EventRepository: CoroutineCrudRepository<Event, Long> {
+    suspend fun findByEndedAfter(@Param("endDate") endDate: LocalDateTime): List<Event>
+}

--- a/src/main/kotlin/sosteam/deamhome/domain/event/service/EventCreateService.kt
+++ b/src/main/kotlin/sosteam/deamhome/domain/event/service/EventCreateService.kt
@@ -15,7 +15,7 @@ class EventCreateService (
     suspend fun createEvent(request: EventRequest): EventInfoResponse{
 
         // 이벤트 시작 날짜가 종료 날짜보다 앞인지 확인
-        if (request.started.isAfter(request.ended)) {
+        if (request.startedAt.isAfter(request.endedAt)) {
             throw InvalidEventTimeException()
         }
 

--- a/src/main/kotlin/sosteam/deamhome/domain/event/service/EventCreateService.kt
+++ b/src/main/kotlin/sosteam/deamhome/domain/event/service/EventCreateService.kt
@@ -1,0 +1,32 @@
+package sosteam.deamhome.domain.event.service
+
+import org.springframework.stereotype.Service
+import sosteam.deamhome.domain.event.exception.InvalidEventTimeException
+import sosteam.deamhome.domain.event.handler.request.EventRequest
+import sosteam.deamhome.domain.event.handler.response.EventInfoResponse
+import sosteam.deamhome.domain.event.repository.EventRepository
+import sosteam.deamhome.global.image.provider.ImageProvider
+
+@Service
+class EventCreateService (
+    private val eventRepository: EventRepository,
+    private val imageProvider: ImageProvider,
+){
+    suspend fun createEvent(request: EventRequest): EventInfoResponse{
+
+        // 이벤트 시작 날짜가 종료 날짜보다 앞인지 확인
+        if (request.started.isAfter(request.ended)) {
+            throw InvalidEventTimeException()
+        }
+
+        val event = request.asDomain().apply{
+            // 이미지 저장
+            images = request.images?.map{
+                imageProvider.saveImage(it.image, it.outer, it.inner, it.resizeWidth, it.resizeHeight)
+                    .fileUrl
+            }?.toMutableList() ?: mutableListOf()
+        }
+        val saved = eventRepository.save(event)
+        return EventInfoResponse.fromEvent(saved)
+    }
+}

--- a/src/main/kotlin/sosteam/deamhome/domain/event/service/EventReadService.kt
+++ b/src/main/kotlin/sosteam/deamhome/domain/event/service/EventReadService.kt
@@ -1,0 +1,27 @@
+package sosteam.deamhome.domain.event.service
+
+import org.springframework.stereotype.Service
+import sosteam.deamhome.domain.event.exception.EventNotFoundException
+import sosteam.deamhome.domain.event.handler.response.EventInfoResponse
+import sosteam.deamhome.domain.event.handler.response.EventItemResponse
+import sosteam.deamhome.domain.event.repository.EventRepository
+import java.time.LocalDateTime
+
+@Service
+class EventReadService (
+    private val eventRepository: EventRepository,
+
+){
+    // 현재 진행중인 이벤트 간략 리스트 리턴
+    suspend fun getEventList():List<EventItemResponse>{
+        val eventList = eventRepository.findByEndedAfter(LocalDateTime.now())
+        return eventList.map{EventItemResponse.fromEvent(it) }
+    }
+
+    // id 기반으로 이벤트 전체 정보 리턴
+    suspend fun getEventInfo(eventId: Long): EventInfoResponse{
+        val event = eventRepository.findById(eventId)
+            ?: throw EventNotFoundException()
+        return EventInfoResponse.fromEvent(event)
+    }
+}

--- a/src/main/kotlin/sosteam/deamhome/domain/event/service/EventReadService.kt
+++ b/src/main/kotlin/sosteam/deamhome/domain/event/service/EventReadService.kt
@@ -2,15 +2,18 @@ package sosteam.deamhome.domain.event.service
 
 import org.springframework.stereotype.Service
 import sosteam.deamhome.domain.event.exception.EventNotFoundException
+import sosteam.deamhome.domain.event.handler.request.EventPageRequest
 import sosteam.deamhome.domain.event.handler.response.EventInfoResponse
 import sosteam.deamhome.domain.event.handler.response.EventItemResponse
 import sosteam.deamhome.domain.event.repository.EventRepository
+import sosteam.deamhome.domain.item.handler.response.ItemResponse
+import sosteam.deamhome.domain.item.service.ItemSearchService
 import java.time.LocalDateTime
 
 @Service
 class EventReadService (
     private val eventRepository: EventRepository,
-
+    private val itemSearchService: ItemSearchService,
 ){
     // 현재 진행중인 이벤트 간략 리스트 리턴
     suspend fun getEventList():List<EventItemResponse>{
@@ -23,5 +26,16 @@ class EventReadService (
         val event = eventRepository.findById(eventId)
             ?: throw EventNotFoundException()
         return EventInfoResponse.fromEvent(event)
+    }
+
+    // 이벤트 아이템 리스트 페이지네이션으로 가져오기
+    suspend fun getEventItems(request: EventPageRequest): List<ItemResponse>{
+        val (eventId, page, pageSize) = request
+        // 해당 이벤트 찾기
+        val event = eventRepository.findById(eventId)
+            ?: throw EventNotFoundException()
+
+        return itemSearchService.findItemByPublicIdIn(
+            event.items,page, pageSize)
     }
 }

--- a/src/main/kotlin/sosteam/deamhome/domain/event/service/EventReadService.kt
+++ b/src/main/kotlin/sosteam/deamhome/domain/event/service/EventReadService.kt
@@ -17,7 +17,7 @@ class EventReadService (
 ){
     // 현재 진행중인 이벤트 간략 리스트 리턴
     suspend fun getEventList():List<EventItemResponse>{
-        val eventList = eventRepository.findByEndedAfter(LocalDateTime.now())
+        val eventList = eventRepository.findByEndedAtAfter(LocalDateTime.now())
         return eventList.map{EventItemResponse.fromEvent(it) }
     }
 

--- a/src/main/kotlin/sosteam/deamhome/domain/event/service/EventReadService.kt
+++ b/src/main/kotlin/sosteam/deamhome/domain/event/service/EventReadService.kt
@@ -1,7 +1,6 @@
 package sosteam.deamhome.domain.event.service
 
 import org.springframework.stereotype.Service
-import sosteam.deamhome.domain.event.exception.EventNotFoundException
 import sosteam.deamhome.domain.event.handler.request.EventPageRequest
 import sosteam.deamhome.domain.event.handler.response.EventInfoResponse
 import sosteam.deamhome.domain.event.handler.response.EventItemResponse
@@ -14,6 +13,7 @@ import java.time.LocalDateTime
 class EventReadService (
     private val eventRepository: EventRepository,
     private val itemSearchService: ItemSearchService,
+    private val eventValidService: EventValidService,
 ){
     // 현재 진행중인 이벤트 간략 리스트 리턴
     suspend fun getEventList():List<EventItemResponse>{
@@ -23,8 +23,7 @@ class EventReadService (
 
     // id 기반으로 이벤트 전체 정보 리턴
     suspend fun getEventInfo(eventId: Long): EventInfoResponse{
-        val event = eventRepository.findById(eventId)
-            ?: throw EventNotFoundException()
+        val event = eventValidService.getEventById(eventId)
         return EventInfoResponse.fromEvent(event)
     }
 
@@ -32,8 +31,7 @@ class EventReadService (
     suspend fun getEventItems(request: EventPageRequest): List<ItemResponse>{
         val (eventId, page, pageSize) = request
         // 해당 이벤트 찾기
-        val event = eventRepository.findById(eventId)
-            ?: throw EventNotFoundException()
+        val event = eventValidService.getEventById(eventId)
 
         return itemSearchService.findItemByPublicIdIn(
             event.items,page, pageSize)

--- a/src/main/kotlin/sosteam/deamhome/domain/event/service/EventValidService.kt
+++ b/src/main/kotlin/sosteam/deamhome/domain/event/service/EventValidService.kt
@@ -1,0 +1,17 @@
+package sosteam.deamhome.domain.event.service
+
+import org.springframework.stereotype.Service
+import sosteam.deamhome.domain.event.entity.Event
+import sosteam.deamhome.domain.event.exception.EventNotFoundException
+import sosteam.deamhome.domain.event.repository.EventRepository
+
+@Service
+class EventValidService (
+    private val eventRepository: EventRepository,
+){
+    suspend fun getEventById(id: Long): Event {
+        return eventRepository.findById(id)
+            ?: throw EventNotFoundException()
+
+    }
+}

--- a/src/main/kotlin/sosteam/deamhome/domain/item/repository/ItemRepository.kt
+++ b/src/main/kotlin/sosteam/deamhome/domain/item/repository/ItemRepository.kt
@@ -16,7 +16,7 @@ interface ItemRepository : CoroutineCrudRepository<Item, Long>, ItemRepositoryCu
 
 	fun findByCategoryPublicIdIn(publicIds: List<String>): Flow<Item>
 
-	fun findByIdIn(ids: List<String>, pageRequest: PageRequest): Flow<Item>
+	fun findByPublicIdIn(publicIds: List<String>, pageRequest: PageRequest): Flow<Item>
 	suspend fun findItemById(id: String): Item?
 
 }

--- a/src/main/kotlin/sosteam/deamhome/domain/item/service/ItemSearchService.kt
+++ b/src/main/kotlin/sosteam/deamhome/domain/item/service/ItemSearchService.kt
@@ -3,6 +3,8 @@ package sosteam.deamhome.domain.item.service
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import sosteam.deamhome.domain.category.entity.ItemCategory
@@ -49,6 +51,14 @@ class ItemSearchService (
         val item = itemRepository.findByPublicId(publicId)
             ?: throw ItemNotFoundException()
         return ItemResponse.fromItem(item)
+    }
+
+    // publicId 리스트를 받아 각 아이템 정보 찾아서 ItemResponse 리스트를 반환하는 함수
+    suspend fun findItemByPublicIdIn(publicIdList: List<String>, page: Int, pageSize: Int = 10): List<ItemResponse>{
+        val pageRequest: PageRequest = PageRequest.of(page, pageSize, Sort.by(Sort.Order.desc("created_at")))
+        return itemRepository.findByPublicIdIn(publicIdList, pageRequest)
+            .toList()
+            .map { ItemResponse.fromItem(it) }
     }
 
     // 하위의 카테고리에 있는 아이템을 반환하는 함수

--- a/src/main/resources/graphql/event/eventMutation.graphqls
+++ b/src/main/resources/graphql/event/eventMutation.graphqls
@@ -1,0 +1,4 @@
+extend type Mutation {
+    # 이벤트 생성
+    createEvent(request: EventRequest!): EventInfoResponse
+}

--- a/src/main/resources/graphql/event/eventQuery.graphqls
+++ b/src/main/resources/graphql/event/eventQuery.graphqls
@@ -4,4 +4,7 @@ extend type Query {
 
     # eventId 이용해서 클릭 시 상세정보 조회
     getEventInfo (eventId: Long): EventInfoResponse
+
+    # 이벤트 관련 item publicId로 아이템 정보 페이지네이션으로 가져오기
+    getEventItems (request: EventPageRequest): [ItemResponse]
 }

--- a/src/main/resources/graphql/event/eventQuery.graphqls
+++ b/src/main/resources/graphql/event/eventQuery.graphqls
@@ -1,0 +1,7 @@
+extend type Query {
+    # 현재 진행중인 이벤트 가져오기
+    getEventList: [EventItemResponse]
+
+    # eventId 이용해서 클릭 시 상세정보 조회
+    getEventInfo (eventId: Long): EventInfoResponse
+}

--- a/src/main/resources/graphql/event/eventRequest.graphqls
+++ b/src/main/resources/graphql/event/eventRequest.graphqls
@@ -1,6 +1,6 @@
 input EventRequest {
-    started: DateTime!
-    ended: DateTime!
+    startedAt: DateTime!
+    endedAt: DateTime!
     title: String! @NotBlank
     contents: String
     thumbnail: String

--- a/src/main/resources/graphql/event/eventRequest.graphqls
+++ b/src/main/resources/graphql/event/eventRequest.graphqls
@@ -7,3 +7,12 @@ input EventRequest {
     items: [String]
     images: [ImageRequest]
 }
+
+input EventPageRequest {
+    # 이벤트 id
+    eventId: Long
+    # 페이지 번호
+    page: Int
+    # 페이지 크기
+    pageSize: Int!
+}

--- a/src/main/resources/graphql/event/eventRequest.graphqls
+++ b/src/main/resources/graphql/event/eventRequest.graphqls
@@ -1,0 +1,9 @@
+input EventRequest {
+    started: DateTime!
+    ended: DateTime!
+    title: String! @NotBlank
+    contents: String
+    thumbnail: String
+    items: [String]
+    images: [ImageRequest]
+}

--- a/src/main/resources/graphql/event/eventResponse.graphqls
+++ b/src/main/resources/graphql/event/eventResponse.graphqls
@@ -1,7 +1,7 @@
 type EventInfoResponse {
     id: Long!
-    started: String!
-    ended: String!
+    startedAt: String!
+    endedAt: String!
     title: String!
     contents: String
     thumbnail: String
@@ -11,8 +11,8 @@ type EventInfoResponse {
 
 type EventItemResponse {
     id: Long!
-    started: String!
-    ended: String!
+    startedAt: String!
+    endedAt: String!
     title: String!
     contents: String
     thumbnail: String

--- a/src/main/resources/graphql/event/eventResponse.graphqls
+++ b/src/main/resources/graphql/event/eventResponse.graphqls
@@ -1,0 +1,19 @@
+type EventInfoResponse {
+    id: Long!
+    started: String!
+    ended: String!
+    title: String!
+    contents: String
+    thumbnail: String
+    items: [String]
+    images: [String]
+}
+
+type EventItemResponse {
+    id: Long!
+    started: String!
+    ended: String!
+    title: String!
+    contents: String
+    thumbnail: String
+}


### PR DESCRIPTION
이벤트 api 상상해서 만들어봤습니다 :smile:

![image](https://github.com/S-OSTeam/shop-api/assets/69834729/c97af0f6-1050-40f6-87e4-ab03f5d5532c)

## 엔티티
- 시작 날짜
- 종료 날짜
- 제목
- 텍스트
- 썸네일
- 광고 이미지 리스트
- 관련 아이템 publicId 리스트


## 기능
- 위의 이미지 ( 진행중인 이벤트 리스트 조회 )
종료날짜가 현재 날짜 이후인 이벤트 [시작날짜, 종료날짜, 제목, 텍스트, 썸네일 이미지] 리스트 리턴
- 클릭시 ( 상세 조회 )
엔티티 전체랑 관련 아이템 publicId 해당 아이템이랑 매핑해서 아이템 리스트 리턴 
- 생성, 삭제 api , 수정은 어디까지 디테일하게 필요할지 몰라서 안만들었는데 필요하면 할게요 ( 관리자만 할 수 있는 거라 세세한 수정api는 필요없을것 같음)
 
## 고려사항
- 이벤트 관련 아이템을 클릭했을 때 리턴하고 싶어서 지금은 각 이벤트 publicId를 갖게 했는데 카테고리 이런걸로도 가져오게 해야하는지 고민중
- 진행중인 이벤트 아래 칸에 오는 이미지 아무거나 오면 안될 것 같아서 썸네일 이미지를 따로 받게 했는데 맞을지 모르겠음
![image](https://github.com/S-OSTeam/shop-api/assets/69834729/0d79c724-12ff-458c-a90d-8cae92760c73)